### PR TITLE
Add W3C CG references, remove FAQ editorializing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,49 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a **W3C Community Group standards proposal** — not a software application. The canonical repo for spec work, issues, and PRs is [w3c-cg/ai-content-disclosure](https://github.com/w3c-cg/ai-content-disclosure/). This personal repo (`dweekly/ai-content-disclosure`) contains the explainer (`README.md`) and legislative tracking.
+
+The proposal enables web authors to declare AI involvement at element-level granularity using four values: `none`, `ai-assisted`, `ai-generated`, `autonomous`. It complements (not replaces) the IETF `AI-Disclosure` HTTP header and C2PA cryptographic provenance.
+
+## Repository Structure
+
+- `README.md` — The spec explainer (primary deliverable; follows [W3C Explainer format](https://www.w3.org/TR/explainer-explainer/))
+- `ROADMAP.md` — Stack-ranked engagement priorities
+- `CHANGELOG.md` — Version history of the explainer
+- `examples/` — Working HTML examples demonstrating attribute usage (basic, mixed-content, JSON-LD)
+
+## Development Workflow
+
+There is no build system, test suite, or CI. Work is documentation, regulatory tracking, and stakeholder engagement.
+
+- Use git branches for major changes (e.g., `codex/` prefix for content work)
+- Commit messages: imperative tense, prefixed with `docs:` for spec changes
+
+## Key Standards Alignment
+
+Changes to the disclosure vocabulary or attribute design **must** maintain alignment with:
+
+- **IETF**: `AI-Disclosure` header modes (`none`, `ai-modified`, `ai-originated`, `machine-generated`) — [draft-abaris-aicdh-00](https://www.ietf.org/archive/id/draft-abaris-aicdh-00.html)
+- **IPTC**: Digital Source Type taxonomy — [cv.iptc.org/newscodes/digitalsourcetype/](https://cv.iptc.org/newscodes/digitalsourcetype/)
+- **WHATWG**: Page-level meta tag proposal — [html#9479](https://github.com/whatwg/html/issues/9479)
+- **Schema.org**: Proposed `aiDisclosure` property on `CreativeWork` — [schemaorg#3391](https://github.com/schemaorg/schemaorg/issues/3391)
+
+The mapping tables in README.md sections "Disclosure Values" and "Vocabulary Alignment with IPTC" are the canonical cross-references. Keep them in sync.
+
+## Active Stakeholder Tracking
+
+- W3C CG: [w3.org/community/ai-content-disclosure](https://www.w3.org/community/ai-content-disclosure/) (David co-chairs)
+- WICG: [proposals#261](https://github.com/WICG/proposals/issues/261)
+- Chromium: [ChromeStatus feature](https://chromestatus.com/feature/5078123181899776)
+- Mozilla: [standards-positions#1344](https://github.com/mozilla/standards-positions/issues/1344)
+- WebKit: [standards-positions#605](https://github.com/WebKit/standards-positions/issues/605)
+
+## Content Guidelines
+
+- The README legislative tracker is scoped to **enacted and pending U.S. state laws affecting AI-generated text/HTML disclosure**. Do not expand scope to media-only or federal-only laws unless they directly affect HTML text labeling.
+- `ai-disclosure="none"` is a **positive assertion** (human-only). Absence of the attribute means "unknown." This distinction is critical throughout the spec.
+- The proposal is **voluntary disclosure**, not detection. Frame accordingly — comparisons to `rel=nofollow` and Schema.org are the right analogies.
+- FAQ and framing should focus on **clear labeling for reader/agent decision-making** — not editorializing about how people should feel about AI-generated content. The goal is transparent signals; value judgments are for the consumer of the signal.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 ## Participate
 
-- [GitHub Issues](https://github.com/dweekly/ai-content-disclosure/issues)
+- [W3C AI Content Disclosure Community Group](https://www.w3.org/community/ai-content-disclosure/)
+  ([GitHub repo](https://github.com/w3c-cg/ai-content-disclosure/)) — the
+  canonical home for spec work, issues, and pull requests
 - [WICG Proposals Issue #261](https://github.com/WICG/proposals/issues/261)
 
 ## Table of Contents
@@ -392,13 +394,13 @@ structured data needs.
 
 ### "This is the evil bit — bad actors won't comply."
 
-This standard serves responsible publishers, regulated industries, and AI
-tool vendors who want to be transparent. It is not a detection mechanism.
-The EU AI Act makes compliance mandatory for covered entities, and major
-platforms already require disclosure in their terms of service.
+This is not a detection mechanism. It is a labeling mechanism for publishers,
+regulated industries, and AI tool vendors. The EU AI Act makes compliance
+mandatory for covered entities, and major platforms already require
+disclosure in their terms of service.
 
 The analogy is `rel=nofollow`: voluntary, widely adopted because it aligns
-incentives, and useful despite being ignorable by bad actors.
+incentives, and useful despite non-universal adoption.
 
 ### "Where do you draw the line with grammar checkers?"
 
@@ -408,10 +410,10 @@ outputs. Deterministic spell-check and thesaurus tools are excluded.
 
 ### "Metadata will be gamed like SEO dates."
 
-True for any self-declared metadata. The standard enables honest disclosure;
-verification requires pairing with C2PA or regulatory auditing. The value is
-in the signal for those who choose to use it honestly — same as Schema.org
-structured data, which search engines use despite its spoofability.
+True for any self-declared metadata. Verification requires pairing with
+C2PA or regulatory auditing. The signal is useful to consumers who encounter
+it — same as Schema.org structured data, which search engines use despite
+its spoofability.
 
 ### "This will stigmatize AI-assisted content."
 
@@ -428,8 +430,9 @@ modern content workflows and remains meaningful as AI tools become ubiquitous.
 
 ## Stakeholder Feedback
 
-| Engine | Status | Link |
-|--------|--------|------|
+| Stakeholder | Status | Link |
+|-------------|--------|------|
+| W3C Community Group | **Formed** (2026-02-03) | [w3.org/community/ai-content-disclosure](https://www.w3.org/community/ai-content-disclosure/) |
 | Chromium | Feature Entry Filed | [ChromeStatus](https://chromestatus.com/feature/5078123181899776) |
 | Gecko (Mozilla) | Position Requested | [mozilla/standards-positions#1344](https://github.com/mozilla/standards-positions/issues/1344) |
 | WebKit | Position Requested | [WebKit/standards-positions#605](https://github.com/WebKit/standards-positions/issues/605) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,6 +22,11 @@ Stack-ranked priorities for the AI Content Disclosure proposal.
   on `CreativeWork` as a comment on
   [schemaorg/schemaorg#3391](https://github.com/schemaorg/schemaorg/issues/3391).
 
+- ~~**Form W3C Community Group**~~ — Done:
+  [w3.org/community/ai-content-disclosure](https://www.w3.org/community/ai-content-disclosure/)
+  launched 2026-02-03. Spec work, issues, and PRs now live in
+  [w3c-cg/ai-content-disclosure](https://github.com/w3c-cg/ai-content-disclosure/).
+
 - **Connect with IPTC** — Verify vocabulary alignment with IPTC Digital
   Source Type maintainers. Ensure the mapping table is accurate and
   future-compatible.


### PR DESCRIPTION
## Summary

- Point to [w3c-cg/ai-content-disclosure](https://github.com/w3c-cg/ai-content-disclosure/) as the canonical repo for spec work, issues, and PRs
- Add the W3C Community Group to the Participate section, Stakeholder Feedback table, and ROADMAP (as completed milestone)
- Remove editorializing language from FAQ answers ("responsible publishers", "honest disclosure", "ignorable by bad actors") — reframe to neutral language that lets signal consumers make their own judgments
- Add CLAUDE.md for Claude Code context

## Test plan

- [ ] Verify all links resolve (W3C CG page, CG GitHub repo)
- [ ] Review FAQ answers read as neutral/factual rather than editorializing
- [ ] Confirm ROADMAP completed items are in chronological order